### PR TITLE
Add JSF Spring calculator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# JSF
-A JSF project is a Java-based web application that uses a component-driven architecture to create dynamic, server-side-rendered user interfaces.
+# JSF Spring Calculator
+
+This project demonstrates a simple calculator application built with **Jakarta Server Faces (JSF)** for the UI, **Spring Framework** for dependency injection, and **Hibernate** for ORM persistence. A history of calculations is stored in a PostgreSQL database. The application follows the MVC pattern.
+
+## Features
+
+- Perform addition, subtraction, multiplication and division.
+- Validation for invalid operations and divide-by-zero.
+- Persist every calculation to a PostgreSQL table.
+- View a table with the full history of calculations.
+
+## Project Structure
+
+```
+src/main/java
+  com.example.calculator.entity       -- JPA entity classes
+  com.example.calculator.repository   -- Data access layer using Hibernate
+  com.example.calculator.service      -- Spring managed services
+  com.example.calculator.web          -- JSF managed beans (controllers)
+src/main/webapp                       -- XHTML views and web resources
+src/main/resources                    -- Spring and Hibernate configuration
+```
+
+## Build
+
+The project uses Maven. Run:
+
+```bash
+mvn clean package
+```
+
+The result is `target/jsf-spring-calculator.war`, which can be deployed to any servlet container such as Tomcat.
+
+## Database Setup
+
+The database schema can be created with the SQL script in `db/schema.sql`.
+
+Example commands (assuming PostgreSQL is installed):
+
+```bash
+createdb calculator
+psql -d calculator -f db/schema.sql
+```
+
+Configure username, password and connection URL in `src/main/resources/applicationContext.xml` if different from the defaults (user `calculator`, password `calculator`).
+
+## Usage
+
+Deploy the generated WAR to your servlet container and access `http://localhost:8080/jsf-spring-calculator/calculator.xhtml`.
+
+Use the form to perform calculations. Results and history will be displayed on the same page.
+
+## Architecture Overview
+
+- **View**: JSF XHTML pages in `src/main/webapp`.
+- **Controller**: `CalculatorBean` managed by JSF and backed by Spring.
+- **Service**: `CalculatorService` where business logic and validation live.
+- **Model**: `Calculation` entity persisted via Hibernate.
+
+Spring manages the service and repository beans as configured in `applicationContext.xml`. Hibernate handles persistence to PostgreSQL, and transactions are managed through Spring annotations.
+
+## Notes
+
+This project serves as a minimal example. In a real production environment you would add authentication, improved error handling, and automated tests.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS calculations (
+    id SERIAL PRIMARY KEY,
+    operand1 DOUBLE PRECISION NOT NULL,
+    operand2 DOUBLE PRECISION NOT NULL,
+    operation VARCHAR(5) NOT NULL,
+    result DOUBLE PRECISION NOT NULL,
+    timestamp TIMESTAMP NOT NULL
+);

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>jsf-spring-calculator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- JSF -->
+        <dependency>
+            <groupId>jakarta.faces</groupId>
+            <artifactId>jakarta.faces-api</artifactId>
+            <version>3.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.3.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>5.3.30</version>
+        </dependency>
+
+        <!-- Hibernate -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.6.15.Final</version>
+        </dependency>
+
+        <!-- PostgreSQL -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.2</version>
+        </dependency>
+
+        <!-- Servlet API -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>jsf-spring-calculator</finalName>
+    </build>
+</project>

--- a/src/main/java/com/example/calculator/entity/Calculation.java
+++ b/src/main/java/com/example/calculator/entity/Calculation.java
@@ -1,0 +1,68 @@
+package com.example.calculator.entity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "calculations")
+public class Calculation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private double operand1;
+    private double operand2;
+    private String operation;
+    private double result;
+    private LocalDateTime timestamp;
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public double getOperand1() {
+        return operand1;
+    }
+
+    public void setOperand1(double operand1) {
+        this.operand1 = operand1;
+    }
+
+    public double getOperand2() {
+        return operand2;
+    }
+
+    public void setOperand2(double operand2) {
+        this.operand2 = operand2;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public double getResult() {
+        return result;
+    }
+
+    public void setResult(double result) {
+        this.result = result;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/example/calculator/repository/CalculationRepository.java
+++ b/src/main/java/com/example/calculator/repository/CalculationRepository.java
@@ -1,0 +1,28 @@
+package com.example.calculator.repository;
+
+import com.example.calculator.entity.Calculation;
+import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+public class CalculationRepository {
+
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    @Transactional
+    public void save(Calculation calculation) {
+        sessionFactory.getCurrentSession().save(calculation);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Calculation> findAll() {
+        return sessionFactory.getCurrentSession()
+                .createQuery("from Calculation", Calculation.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/example/calculator/service/CalculatorService.java
+++ b/src/main/java/com/example/calculator/service/CalculatorService.java
@@ -1,0 +1,51 @@
+package com.example.calculator.service;
+
+import com.example.calculator.entity.Calculation;
+import com.example.calculator.repository.CalculationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class CalculatorService {
+
+    @Autowired
+    private CalculationRepository repository;
+
+    public Calculation calculate(double a, double b, String operation) {
+        double result;
+        switch (operation) {
+            case "+":
+                result = a + b;
+                break;
+            case "-":
+                result = a - b;
+                break;
+            case "*":
+                result = a * b;
+                break;
+            case "/":
+                if (b == 0) {
+                    throw new ArithmeticException("Divide by zero");
+                }
+                result = a / b;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid operation");
+        }
+        Calculation calc = new Calculation();
+        calc.setOperand1(a);
+        calc.setOperand2(b);
+        calc.setOperation(operation);
+        calc.setResult(result);
+        calc.setTimestamp(LocalDateTime.now());
+        repository.save(calc);
+        return calc;
+    }
+
+    public List<Calculation> history() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/example/calculator/web/CalculatorBean.java
+++ b/src/main/java/com/example/calculator/web/CalculatorBean.java
@@ -1,0 +1,74 @@
+package com.example.calculator.web;
+
+import com.example.calculator.entity.Calculation;
+import com.example.calculator.service.CalculatorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+@Component
+@Scope("request")
+public class CalculatorBean {
+
+    private double operand1;
+    private double operand2;
+    private String operation = "+";
+    private double result;
+    private List<Calculation> history;
+
+    @Autowired
+    private CalculatorService service;
+
+    @PostConstruct
+    public void init() {
+        history = service.history();
+    }
+
+    public String calculate() {
+        try {
+            Calculation calc = service.calculate(operand1, operand2, operation);
+            result = calc.getResult();
+            history = service.history();
+        } catch (ArithmeticException | IllegalArgumentException e) {
+            // Simple error handling: store negative sentinel value
+            result = Double.NaN;
+        }
+        return null;
+    }
+
+    // Getters and setters
+    public double getOperand1() {
+        return operand1;
+    }
+
+    public void setOperand1(double operand1) {
+        this.operand1 = operand1;
+    }
+
+    public double getOperand2() {
+        return operand2;
+    }
+
+    public void setOperand2(double operand2) {
+        this.operand2 = operand2;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public double getResult() {
+        return result;
+    }
+
+    public List<Calculation> getHistory() {
+        return history;
+    }
+}

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+    <context:component-scan base-package="com.example.calculator"/>
+
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.postgresql.Driver"/>
+        <property name="url" value="jdbc:postgresql://localhost:5432/calculator"/>
+        <property name="username" value="calculator"/>
+        <property name="password" value="calculator"/>
+    </bean>
+
+    <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
+        <property name="dataSource" ref="dataSource"/>
+        <property name="packagesToScan" value="com.example.calculator.entity"/>
+        <property name="hibernateProperties">
+            <props>
+                <prop key="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</prop>
+                <prop key="hibernate.hbm2ddl.auto">update</prop>
+                <prop key="hibernate.show_sql">true</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
+        <property name="sessionFactory" ref="sessionFactory"/>
+    </bean>
+
+    <tx:annotation-driven transaction-manager="transactionManager"/>
+</beans>

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+    <context:component-scan base-package="com.example.calculator"/>
+
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.postgresql.Driver"/>
+        <property name="url" value="jdbc:postgresql://localhost:5432/calculator"/>
+        <property name="username" value="calculator"/>
+        <property name="password" value="calculator"/>
+    </bean>
+
+    <bean id="sessionFactory" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
+        <property name="dataSource" ref="dataSource"/>
+        <property name="packagesToScan" value="com.example.calculator.entity"/>
+        <property name="hibernateProperties">
+            <props>
+                <prop key="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</prop>
+                <prop key="hibernate.hbm2ddl.auto">update</prop>
+                <prop key="hibernate.show_sql">true</prop>
+            </props>
+        </property>
+    </bean>
+
+    <bean id="transactionManager" class="org.springframework.orm.hibernate5.HibernateTransactionManager">
+        <property name="sessionFactory" ref="sessionFactory"/>
+    </bean>
+
+    <tx:annotation-driven transaction-manager="transactionManager"/>
+</beans>

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee" version="3.0">
+</faces-config>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee" version="5.0">
+    <display-name>Calculator</display-name>
+
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>/WEB-INF/applicationContext.xml</param-value>
+    </context-param>
+
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+
+    <servlet>
+        <servlet-name>facesServlet</servlet-name>
+        <servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>facesServlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <welcome-file-list>
+        <welcome-file>calculator.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>

--- a/src/main/webapp/calculator.xhtml
+++ b/src/main/webapp/calculator.xhtml
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:h="http://xmlns.jcp.org/jsf/html">
+<h:head>
+    <title>Calculator</title>
+</h:head>
+<h:body>
+<h:form>
+    <h:panelGrid columns="2" cellpadding="5">
+        <h:outputLabel for="op1" value="Operand 1:"/>
+        <h:inputText id="op1" value="#{calculatorBean.operand1}" required="true"/>
+
+        <h:outputLabel for="op2" value="Operand 2:"/>
+        <h:inputText id="op2" value="#{calculatorBean.operand2}" required="true"/>
+
+        <h:outputLabel for="operation" value="Operation:"/>
+        <h:selectOneMenu id="operation" value="#{calculatorBean.operation}">
+            <f:selectItem itemValue="+" itemLabel="+"/>
+            <f:selectItem itemValue="-" itemLabel="-"/>
+            <f:selectItem itemValue="*" itemLabel="*"/>
+            <f:selectItem itemValue="/" itemLabel="/"/>
+        </h:selectOneMenu>
+    </h:panelGrid>
+    <h:commandButton value="Calculate" action="#{calculatorBean.calculate}"/>
+    <h:outputText value="Result: #{calculatorBean.result}" style="margin-left:10px"/>
+</h:form>
+
+<h2>History</h2>
+<h:dataTable value="#{calculatorBean.history}" var="item" border="1">
+    <h:column>
+        <f:facet name="header">Operand1</f:facet>
+        #{item.operand1}
+    </h:column>
+    <h:column>
+        <f:facet name="header">Operation</f:facet>
+        #{item.operation}
+    </h:column>
+    <h:column>
+        <f:facet name="header">Operand2</f:facet>
+        #{item.operand2}
+    </h:column>
+    <h:column>
+        <f:facet name="header">Result</f:facet>
+        #{item.result}
+    </h:column>
+    <h:column>
+        <f:facet name="header">Time</f:facet>
+        #{item.timestamp}
+    </h:column>
+</h:dataTable>
+</h:body>
+</html>


### PR DESCRIPTION
## Summary
- set up Maven project with JSF, Spring and Hibernate
- implement `Calculation` entity and persistence layer
- add `CalculatorService` and `CalculatorBean`
- create JSF view and Spring/JSF configs
- provide PostgreSQL schema and README instructions

## Testing
- `mvn -q -DskipTests package` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857eb293d7483309337740d7075b11f